### PR TITLE
Default to search command if no slash command was called

### DIFF
--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"fmt"
 	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -98,7 +99,7 @@ func (b *Bot) StartBot() {
 
 		// If no command was passed we will handle a search command.
 		if update.Message.Entities == nil {
-			update.Message.Text = "/q " + update.Message.Text
+			update.Message.Text = fmt.Sprintf("/q %s", update.Message.Text)
 			update.Message.Entities = []tgbotapi.MessageEntity{{
 				Type:   "bot_command",
 				Length: 2, // length of the command `/q`

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -96,6 +96,15 @@ func (b *Bot) StartBot() {
 			continue
 		}
 
+		// If no command was passed we will handle a search command.
+		if update.Message.Entities == nil {
+			update.Message.Text = "/q " + update.Message.Text
+			update.Message.Entities = []tgbotapi.MessageEntity{{
+				Type:   "bot_command",
+				Length: 2, // length of the command `/q`
+			}}
+		}
+
 		if update.Message.IsCommand() {
 			b.handleCommand(b.Bot, update, b.RadarrServer)
 		}


### PR DESCRIPTION
If not slash command was passed we can default to the search command `/q`.