### PR TITLE
Fix nil pointer during cancel

### DIFF
--- a/pkg/bot/add.go
+++ b/pkg/bot/add.go
@@ -38,7 +38,7 @@ func (b *Bot) addMovie(update tgbotapi.Update) bool {
 			command.confirmation = true
 			//movie already in library...
 			if command.movie.ID != 0 {
-				b.clearState(update.CallbackQuery.From.ID)
+				b.clearState(update)
 				msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, "Movie already exists in your library.\nAll commands have been cleared.")
 				b.sendMessage(msg)
 				return false
@@ -67,13 +67,13 @@ func (b *Bot) addMovie(update tgbotapi.Update) bool {
 				} else {
 					b.AddMovieUserStates[update.CallbackQuery.From.ID] = command
 					msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, utils.Escape("No quality profile(s) found on your radarr server.\nAll commands have been cleared."))
-					b.clearState(update.CallbackQuery.From.ID)
+					b.clearState(update)
 					b.sendMessage(msg)
 					return false
 				}
 			}
 		case "ADDMOVIE_CANCEL":
-			b.clearState(update.CallbackQuery.From.ID)
+			b.clearState(update)
 			msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, "All commands have been cleared")
 			b.sendMessage(msg)
 			return false
@@ -120,7 +120,7 @@ func (b *Bot) addMovie(update tgbotapi.Update) bool {
 		} else {
 			b.AddMovieUserStates[update.CallbackQuery.From.ID] = command
 			msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, utils.Escape("No root folder(s) found on your radarr server.\nAll commands have been cleared."))
-			b.clearState(update.CallbackQuery.From.ID)
+			b.clearState(update)
 			b.sendMessage(msg)
 			return false
 		}
@@ -164,7 +164,7 @@ func (b *Bot) addMovie(update tgbotapi.Update) bool {
 				Monitor:        "none",
 			}
 		case "MONITORED_CANCEL":
-			b.clearState(update.CallbackQuery.From.ID)
+			b.clearState(update)
 			msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, "All commands have been cleared")
 			b.sendMessage(msg)
 			return false

--- a/pkg/bot/bot.go
+++ b/pkg/bot/bot.go
@@ -85,7 +85,7 @@ func (b *Bot) StartBot() {
 				}
 			default:
 				// Handle unexpected callback queries
-				b.clearState(update.CallbackQuery.From.ID)
+				b.clearState(update)
 				msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, "I am not sure what you mean.\nAll commands have been cleared")
 				b.sendMessage(msg)
 				break
@@ -102,7 +102,11 @@ func (b *Bot) StartBot() {
 	}
 }
 
-func (b *Bot) clearState(userID int64) {
+func (b *Bot) clearState(update tgbotapi.Update) {
+	userID := update.Message.From.ID
+	if update.CallbackQuery != nil {
+		userID = update.CallbackQuery.From.ID
+	}
 	delete(b.UserActiveCommand, userID)
 	delete(b.AddMovieUserStates, userID)
 	delete(b.DeleteMovieUserStates, userID)

--- a/pkg/bot/command.go
+++ b/pkg/bot/command.go
@@ -54,7 +54,7 @@ func (b *Bot) handleCommand(bot *tgbotapi.BotAPI, update tgbotapi.Update, r *rad
 		b.sendSearchResults(command.searchResults, &msg)
 
 	case "clear", "cancel", "stop":
-		b.clearState(update.CallbackQuery.From.ID)
+		b.clearState(update)
 		msg.Text = "All commands have been cleared"
 		b.sendMessage(msg)
 

--- a/pkg/bot/delete.go
+++ b/pkg/bot/delete.go
@@ -64,7 +64,7 @@ func (b *Bot) deleteMovie(update tgbotapi.Update) bool {
 			b.sendLibraryAsInlineKeyboard(movies, &msg)
 			return false
 		} else if update.CallbackQuery.Data == "DELETEMOVIE_CANCEL" {
-			b.clearState(update.CallbackQuery.From.ID)
+			b.clearState(update)
 			msg := tgbotapi.NewMessage(update.CallbackQuery.Message.Chat.ID, "All commands have been cleared")
 			b.sendMessage(msg)
 			return false


### PR DESCRIPTION
There was a nil pointer exception calling the `/cancel` command because `update.CallbackQuery` was `nil`.
This PR fixes this bug.